### PR TITLE
Fix fabric module resource references

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ module "fabric" {
   workspace_name    = "ws-${var.name}"
   location          = var.location
   capacity_sku      = var.fabric_capacity_sku
-  resource_group_id = module.resource_group.id
+  resource_group_name = module.resource_group.name
   administrator_upns = [
     data.azuread_user.current.user_principal_name,
   ]

--- a/modules/fabric/main.tf
+++ b/modules/fabric/main.tf
@@ -9,8 +9,8 @@ terraform {
     fabric = {
       source = "microsoft/fabric"
     }
-    azapi = {
-      source = "azure/azapi"
+    azurerm = {
+      source = "hashicorp/azurerm"
     }
   }
 }
@@ -35,21 +35,16 @@ resource "azurerm_fabric_capacity" "this" {
   tags = var.tags
 }
 
-# Retrieve the Fabric capacity information once provisioned.
-data "fabric_capacity" "this" {
-  display_name = azapi_resource.capacity.name
-}
-
 # Create a Fabric workspace bound to the capacity.
 resource "fabric_workspace" "this" {
-  capacity_id  = data.fabric_capacity.this.id
+  capacity_id  = azurerm_fabric_capacity.this.id
   display_name = var.workspace_name
 }
 
 # Expose useful outputs to calling modules.
 output "capacity" {
   description = "Fabric capacity details including identifiers."
-  value       = data.fabric_capacity.this
+  value       = azurerm_fabric_capacity.this
 }
 
 output "workspace" {

--- a/modules/fabric/variables.tf
+++ b/modules/fabric/variables.tf
@@ -22,8 +22,8 @@ variable "capacity_sku" {
   type        = string
 }
 
-variable "resource_group_id" {
-  description = "Resource group identifier where the capacity will reside."
+variable "resource_group_name" {
+  description = "Name of the resource group where the capacity will reside."
   type        = string
 }
 


### PR DESCRIPTION
## Summary
- pass the resource group name into the fabric module so the capacity resource can be created
- update the fabric module to rely on the azurerm fabric capacity resource directly and drop the unused azapi dependency

## Testing
- not run (terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fb52230f10832697558ea5e43097a7